### PR TITLE
move react to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "classnames": "^2.3.0",
-    "prismjs": "^1.23.0",
-    "react": "^16.12.0"
+    "prismjs": "^1.23.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.13.10",
@@ -48,6 +47,7 @@
     "less-loader": "^5.0.0",
     "lint-staged": "^10.0.7",
     "prettier": "^1.19.1",
+    "react": "^16.12.0",
     "style-loader": "^2.0.0",
     "typescript": "^4.2.3",
     "webpack": "^4.40.2",


### PR DESCRIPTION
because there should be a unique React in every project, React must be in devDependencies in npm libraries. after this change, I tested the project within a project with react 18 and it worked seamlessly.